### PR TITLE
add a warning for users with no email address stored

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ SRCS = \
 	cs_access.c		\
 	cs_successor_freenodestaff.c \
 	regnotice.c \
-        noemailnotice.c
+	noemailnotice.c
 
 # To compile your own modules, add them to SRCS or make blegh.so
 

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ SRCS = \
         log_sasl_fail.c \
 	cs_access.c		\
 	cs_successor_freenodestaff.c \
-	regnotice.c
+	regnotice.c \
+        noemailnotice.c
 
 # To compile your own modules, add them to SRCS or make blegh.so
 

--- a/noemailnotice.c
+++ b/noemailnotice.c
@@ -37,9 +37,9 @@ static void user_identify_notice(user_t *u)
 	}
 	if (!validemail(mu->email))
 	{
-		notice(nicksvs.nick, mu, "WARNING: Your NickServ account does not have a valid email address set.");
-		notice(nicksvs.nick, mu, "Should you forget your password it may not be possible to recover your acccount.");
-		notice(nicksvs.nick, mu, "For help setting an email address, see \2/msg NickServ HELP SET EMAIL\2.");
-		notice(nicksvs.nick, mu, "Should you need more assistance you can /join #freenode to find network staff.");
+		notice(nicksvs.nick, u->nick, "WARNING: Your NickServ account does not have a valid email address set.");
+		notice(nicksvs.nick, u->nick, "Should you forget your password it may not be possible to recover your acccount.");
+		notice(nicksvs.nick, u->nick, "For help setting an email address, see \2/msg NickServ HELP SET EMAIL\2.");
+		notice(nicksvs.nick, u->nick, "Should you need more assistance you can /join #freenode to find network staff.");
 	}
 }

--- a/noemailnotice.c
+++ b/noemailnotice.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016 Mike Quin
+ * Rights to this code are as documented in doc/LICENSE.
+ *
+ * freenode on-identify notice to users with no valid email address set
+ *
+ */
+
+#include "atheme.h"
+
+DECLARE_MODULE_V1
+(
+	"freenode/noemailnotice", FALSE, _modinit, _moddeinit,
+	PACKAGE_STRING,
+	"freenode <http://freenode.net>"
+);
+
+static void user_identify_notice(user_t *u);
+
+void _modinit(module_t *m)
+{
+	hook_add_event("user_identify");
+	hook_add_user_identify(user_identify_notice);
+}
+
+void _moddeinit(module_unload_intent_t intentvoid)
+{
+	hook_del_user_identify(user_identify_notice);
+}
+
+static void user_identify_notice(user_t *u)
+{
+	myuser_t *mu = u->myuser;
+	if (mu->flags & MU_WAITAUTH)
+	{
+		return;
+	}
+	if (!validemail(mu->email))
+	{
+		myuser_notice(nicksvs.nick, mu, "WARNING: Your NickServ account does not have a valid email address set.");
+		myuser_notice(nicksvs.nick, mu, "Should you forget your password it may not be possible to recover your acccount.");
+		myuser_notice(nicksvs.nick, mu, "For help setting an email address, see \2/msg NickServ HELP SET EMAIL\2.");
+		myuser_notice(nicksvs.nick, mu, "Should you need more assistance you can /join #freenode to find network staff.");
+	}
+}

--- a/noemailnotice.c
+++ b/noemailnotice.c
@@ -37,9 +37,9 @@ static void user_identify_notice(user_t *u)
 	}
 	if (!validemail(mu->email))
 	{
-		myuser_notice(nicksvs.nick, mu, "WARNING: Your NickServ account does not have a valid email address set.");
-		myuser_notice(nicksvs.nick, mu, "Should you forget your password it may not be possible to recover your acccount.");
-		myuser_notice(nicksvs.nick, mu, "For help setting an email address, see \2/msg NickServ HELP SET EMAIL\2.");
-		myuser_notice(nicksvs.nick, mu, "Should you need more assistance you can /join #freenode to find network staff.");
+		notice(nicksvs.nick, mu, "WARNING: Your NickServ account does not have a valid email address set.");
+		notice(nicksvs.nick, mu, "Should you forget your password it may not be possible to recover your acccount.");
+		notice(nicksvs.nick, mu, "For help setting an email address, see \2/msg NickServ HELP SET EMAIL\2.");
+		notice(nicksvs.nick, mu, "Should you need more assistance you can /join #freenode to find network staff.");
 	}
 }


### PR DESCRIPTION
This adds a services module which will send a short notice on identification to users who do not have a valid email address associated with their NickServ registration advising them to set one.
