### PR TITLE
Add projectserv/audit - audit incomplete projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ SRCS = \
 	projectns/hooks.c \
 	projectns/set.c \
 	projectns/manage.c \
+	projectns/audit.c \
 	projectns/cs_claim.c
 
 # To compile your own modules, add them to SRCS or make blegh.so

--- a/help/freenode/project_audit
+++ b/help/freenode/project_audit
@@ -1,0 +1,9 @@
+Help for AUDIT:
+
+AUDIT finds all registered projects with incomplete registrations.
+
+Syntax: AUDIT [CHANNELS|CONTACTS]
+
+Examples:
+    /msg &nick& AUDIT
+    /msg &nick& AUDIT CHANNELS

--- a/projectns/audit.c
+++ b/projectns/audit.c
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2020 Gareth Pulham, Nicole Kleinhoff
+ * Rights to this code are as documented in doc/LICENSE.
+ *
+ * Services awareness of group registrations
+ * Command to audit incompletely registered projects
+ */
+
+#include "fn-compat.h"
+#include "atheme.h"
+#include "projectns.h"
+
+static void cmd_audit(sourceinfo_t *si, int parc, char *parv[]);
+
+command_t ps_audit = {
+	.name	   = "AUDIT",
+	.desc	   = N_("Lists projects with incomplete registrations"),
+	.access	 = PRIV_PROJECT_AUSPEX,
+	.maxparc	= 1,
+	.cmd		= cmd_audit,
+	.help	   = { .path = "freenode/project_audit" }
+};
+
+static void cmd_audit(sourceinfo_t *si, int parc, char *parv[])
+{
+	char *modestr = parv[0];
+	int check_channels = 0;
+	int check_contacts = 0;
+
+	if (parc == 0)
+		check_channels = check_contacts = 1;
+	else if (strcasecmp(parv[0], "CHANNELS") == 0)
+		check_channels = 1;
+	else if (strcasecmp(parv[0], "CONTACTS") == 0)
+		check_contacts = 1;
+	else
+	{
+		command_fail(si, fault_badparams, STR_INVALID_PARAMS, "AUDIT");
+		command_fail(si, fault_badparams, _("Syntax: AUDIT [CHANNELS|CONTACTS]"));
+		return;
+	}
+
+	mowgli_patricia_iteration_state_t state;
+	struct projectns *project;
+	unsigned int matches = 0;
+
+	command_success_nodata(si, _("Projects in need of attention:"));
+
+	MOWGLI_PATRICIA_FOREACH(project, &state, projectsvs->projects)
+	{
+		char channels[BUFSIZE] = "";
+		mowgli_node_t *n;
+		MOWGLI_ITER_FOREACH(n, project->channel_ns.head)
+		{
+			if (channels[0])
+				mowgli_strlcat(channels, ", ", sizeof channels);
+			mowgli_strlcat(channels, (const char*)n->data, sizeof channels);
+		}
+
+		char contacts[BUFSIZE] = "";
+		MOWGLI_ITER_FOREACH(n, project->contacts.head)
+		{
+			if (contacts[0])
+				mowgli_strlcat(contacts, ", ", sizeof contacts);
+			mowgli_strlcat(contacts, ((myentity_t*)n->data)->name, sizeof contacts);
+		}
+
+		int flagged = 0;
+		flagged |= check_channels & !channels[0];
+		flagged |= check_contacts & !contacts[0];
+
+		if (flagged)
+		{
+			matches++;
+			command_success_nodata(si, _("- %s (%s; %s)"), project->name,
+									   (channels[0] ? channels : _("\2no channels\2")),
+									   (contacts[0] ? contacts : _("\2no contacts\2")));
+		}
+	}
+
+	if (matches == 0)
+		command_success_nodata(si, _("All projects correctly registered."));
+	else
+		command_success_nodata(si, ngettext(N_("\2%d\2 project in need of attention."),
+											N_("\2%d\2 projects in need of attention."),
+											matches), matches);
+	logcommand(si, CMDLOG_ADMIN, "PROJECT:AUDIT: \2%d\2 projects", matches);
+}
+
+static void mod_init(module_t *const restrict m)
+{
+	if (!use_projectns_main_symbols(m))
+		return;
+	service_named_bind_command("projectserv", &ps_audit);
+}
+
+static void mod_deinit(const module_unload_intent_t unused)
+{
+	service_named_unbind_command("projectserv", &ps_audit);
+}
+
+DECLARE_MODULE_V1
+(
+	"freenode/projectns/audit", MODULE_UNLOAD_CAPABILITY_OK, mod_init, mod_deinit,
+	"", "freenode <http://www.freenode.net>"
+);


### PR DESCRIPTION
## Tests
In-band:
```
<kline> list *
-ProjectServ- Registered projects matching pattern *:
-ProjectServ- - correct (#correct; adam)
-ProjectServ- - nochan (no channels; eve)
-ProjectServ- - nocontact (#nocontact; no contacts)
-ProjectServ- - nothing (no channels; no contacts)
-ProjectServ- 4 matches for pattern *

<kline> audit
-ProjectServ- Projects in need of attention:
-ProjectServ- - nochan (no channels; eve)
-ProjectServ- - nocontact (#nocontact; no contacts)
-ProjectServ- - nothing (no channels; no contacts)
-ProjectServ- 3 projects in need of attention.

<kline> audit channels
-ProjectServ- Projects in need of attention:
-ProjectServ- - nochan (no channels; eve)
-ProjectServ- - nothing (no channels; no contacts)
-ProjectServ- 2 projects in need of attention.

<kline> audit contacts
-ProjectServ- Projects in need of attention:
-ProjectServ- - nocontact (#nocontact; no contacts)
-ProjectServ- - nothing (no channels; no contacts)
-ProjectServ- 2 projects in need of attention.

<kline> help audit
-ProjectServ- ***** ProjectServ Help *****
-ProjectServ-  
-ProjectServ- Help for AUDIT:
-ProjectServ-  
-ProjectServ- AUDIT finds all registered projects with incomplete registrations.
-ProjectServ-  
-ProjectServ- Syntax: AUDIT [CHANNELS|CONTACTS]
-ProjectServ-  
-ProjectServ- Examples:
-ProjectServ-     /msg ProjectServ AUDIT
-ProjectServ-     /msg ProjectServ AUDIT CHANNELS
-ProjectServ-  
-ProjectServ- ***** End of Help *****
```

Atheme logs:
```
[2020-05-13 23:26:14] ProjectServ :kline!~kline@localhost[0::1] PROJECT:LIST: * (4 matches)
[2020-05-13 23:26:18] ProjectServ :kline!~kline@localhost[0::1] PROJECT:AUDIT: 3 projects
[2020-05-13 23:26:23] ProjectServ :kline!~kline@localhost[0::1] PROJECT:AUDIT: 2 projects
[2020-05-13 23:26:25] ProjectServ :kline!~kline@localhost[0::1] PROJECT:AUDIT: 2 projects
```